### PR TITLE
Correct package name of libprotobuf in setup.sh.

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,7 +18,7 @@ CTEMPLATE_PKGS="libctemplate-dev"
 LIBPROTOBUF="libprotobuf-c0-dev"
 OS_ID=$(lsb_release -i -s)
 OS_RELEASE=`lsb_release -r -s | awk '{split( $0, a, "."); print a[ 1]}'`
-if [ $OS_ID == "Ubuntu" -a $OS_RELEASE -gt 14 ]
+if [ $OS_ID == "Ubuntu" -a $OS_RELEASE -gt 14 ] || [ $OS_ID == "Debian" ]
 then
 	LIBPROTOBUF="libprotobuf-c-dev"
 fi


### PR DESCRIPTION
The name is libprotobuf-c-dev, like in Ubuntu, for all versions I checked:
* [Jessie](https://packages.debian.org/search?suite=jessie&searchon=names&keywords=libprotobuf-c-dev)
* [Strech](https://packages.debian.org/search?suite=stretch&searchon=names&keywords=libprotobuf-c-dev)
* [Buster](https://packages.debian.org/search?suite=buster&searchon=names&keywords=libprotobuf-c-dev)
* [Sid](https://packages.debian.org/search?suite=sid&searchon=names&keywords=libprotobuf-c-dev)